### PR TITLE
Windows path fix

### DIFF
--- a/src/Iterator/RegexFilterIterator.php
+++ b/src/Iterator/RegexFilterIterator.php
@@ -13,6 +13,7 @@ namespace Webmozart\Glob\Iterator;
 
 use FilterIterator;
 use Iterator;
+use Webmozart\PathUtil\Path;
 
 /**
  * Filters an iterator by a regular expression.
@@ -139,7 +140,7 @@ class RegexFilterIterator extends FilterIterator
      */
     public function accept()
     {
-        $path = ($this->mode & self::FILTER_VALUE) ? $this->current() : parent::key();
+        $path = Path::normalize(($this->mode & self::FILTER_VALUE) ? $this->current() : parent::key());
 
         if (0 !== strpos($path, $this->staticPrefix)) {
             return false;

--- a/tests/Iterator/GlobIteratorTest.php
+++ b/tests/Iterator/GlobIteratorTest.php
@@ -15,6 +15,7 @@ use PHPUnit_Framework_TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\Glob\Glob;
 use Webmozart\Glob\Iterator\GlobIterator;
+use Webmozart\PathUtil\Path;
 
 /**
  * @since  1.0
@@ -29,7 +30,7 @@ class GlobIteratorTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        while (false === @mkdir($this->tempDir = sys_get_temp_dir().'/webmozart-glob/GlobIteratorTest'.rand(10000, 99999), 0777, true)) {
+        while (false === @mkdir($this->tempDir = Path::normalize(sys_get_temp_dir()).'/webmozart-glob/GlobIteratorTest'.rand(10000, 99999), 0777, true)) {
         }
 
         $filesystem = new Filesystem();


### PR DESCRIPTION
Normalize path to fix windows backslash issues.

Tests are still broken on windows, since the GlobIterator relies on the RecursiveDirectoryIterator, which returns backslashes on windows.