### PR TITLE
Support running under `alpine` and `musl`-based environments: use `GLOB_BRACE` only when defined

### DIFF
--- a/.github/workflows/alpine.dockerfile
+++ b/.github/workflows/alpine.dockerfile
@@ -1,3 +1,3 @@
 ARG PHP_VERSION
-FROM php:{$PHP_VERSION}-cli-alpine
+FROM php:${PHP_VERSION}-cli-alpine
 COPY . .

--- a/.github/workflows/alpine.dockerfile
+++ b/.github/workflows/alpine.dockerfile
@@ -1,2 +1,3 @@
-FROM php:8-cli-alpine
+ARG PHP_VERSION
+FROM php:{$PHP_VERSION}-cli-alpine
 COPY . .

--- a/.github/workflows/alpine.dockerfile
+++ b/.github/workflows/alpine.dockerfile
@@ -1,0 +1,2 @@
+FROM php:8-cli-alpine
+COPY . .

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -63,8 +63,7 @@ jobs:
 
       - name: "Build Alpine image"
         if: ${{ matrix.operating-system == 'ubuntu-latest' }}
-        # todo: image per tag
-        run: docker build --file .github/workflows/alpine.dockerfile --tag testenv .
+        run: docker build --file .github/workflows/alpine.dockerfile --build-arg=${{ matrix.php-version }} --tag testenv .
 
       - name: "Test under Alpine"
         if: ${{ matrix.operating-system == 'ubuntu-latest' }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -61,49 +61,11 @@ jobs:
       - name: "Tests"
         run: "vendor/bin/phpunit"
 
-  phpunit-alpine:
-    name: "PHPUnit tests under Alpine"
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-          dependencies:
-            - "lowest"
-            - "highest"
-            - "locked"
-          php-version:
-            - "7.3"
-            - "7.4"
-            - "8.0"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v2"
-
-      - name: "Cache dependencies"
-        uses: "actions/cache@v2"
-        with:
-          path: |
-            ~/.composer/cache
-            vendor
-          key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
-          restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
-
-      - name: "Install lowest dependencies"
-        if: ${{ matrix.dependencies == 'lowest' }}
-        run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest"
-
-      - name: "Install highest dependencies"
-        if: ${{ matrix.dependencies == 'highest' }}
-        run: "composer update --no-interaction --no-progress --no-suggest"
-
-      - name: "Install locked dependencies"
-        if: ${{ matrix.dependencies == 'locked' }}
-        run: "composer install --no-interaction --no-progress --no-suggest"
-
       - name: "Build Alpine image"
+        if: ${{ matrix.operating-system == 'ubuntu-latest' }}
+        # todo: image per tag
         run: docker build --file .github/workflows/alpine.dockerfile --tag testenv .
 
-      - name: "Tests"
+      - name: "Test under Alpine"
+        if: ${{ matrix.operating-system == 'ubuntu-latest' }}
         run: docker run testenv vendor/bin/phpunit

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -60,3 +60,50 @@ jobs:
 
       - name: "Tests"
         run: "vendor/bin/phpunit"
+
+  phpunit-alpine:
+    name: "PHPUnit tests under Alpine"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+          dependencies:
+            - "lowest"
+            - "highest"
+            - "locked"
+          php-version:
+            - "7.3"
+            - "7.4"
+            - "8.0"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+
+      - name: "Cache dependencies"
+        uses: "actions/cache@v2"
+        with:
+          path: |
+            ~/.composer/cache
+            vendor
+          key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
+          restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
+
+      - name: "Install lowest dependencies"
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest"
+
+      - name: "Install highest dependencies"
+        if: ${{ matrix.dependencies == 'highest' }}
+        run: "composer update --no-interaction --no-progress --no-suggest"
+
+      - name: "Install locked dependencies"
+        if: ${{ matrix.dependencies == 'locked' }}
+        run: "composer install --no-interaction --no-progress --no-suggest"
+
+      - name: "Build Alpine image"
+        run: docker build --file .github/workflows/alpine.dockerfile --tag testenv .
+
+      - name: "Tests"
+        run: docker run testenv vendor/bin/phpunit

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -63,7 +63,11 @@ jobs:
 
       - name: "Build Alpine image"
         if: ${{ matrix.operating-system == 'ubuntu-latest' }}
-        run: docker build --file .github/workflows/alpine.dockerfile --build-arg=${{ matrix.php-version }} --tag testenv .
+        run: docker build
+          --file .github/workflows/alpine.dockerfile
+          --build-arg PHP_VERSION=${{ matrix.php-version }}
+          --tag testenv
+          .
 
       - name: "Test under Alpine"
         if: ${{ matrix.operating-system == 'ubuntu-latest' }}

--- a/src/Iterator/GlobIterator.php
+++ b/src/Iterator/GlobIterator.php
@@ -52,7 +52,8 @@ class GlobIterator extends IteratorIterator
                 // glob() does not support [^...] on Windows
                 ('\\' !== DIRECTORY_SEPARATOR || false === strpos($glob, '[^'))
             ) {
-                $results = glob($glob, GLOB_BRACE);
+                // GLOB_BRACE is not available in some environments.
+                $results = glob($glob, defined('GLOB_BRACE') ? GLOB_BRACE : 0);
 
                 // $results may be empty or false if $glob is invalid
                 if (empty($results)) {

--- a/src/Iterator/GlobIterator.php
+++ b/src/Iterator/GlobIterator.php
@@ -53,8 +53,7 @@ class GlobIterator extends IteratorIterator
                 ('\\' !== DIRECTORY_SEPARATOR || false === strpos($glob, '[^'))
             ) {
                 // GLOB_BRACE is not available in some environments.
-                // $results = glob($glob, defined('GLOB_BRACE') ? GLOB_BRACE : 0);
-                $results = glob($glob, GLOB_BRACE);
+                $results = glob($glob, defined('GLOB_BRACE') ? GLOB_BRACE : 0);
 
                 // $results may be empty or false if $glob is invalid
                 if (empty($results)) {

--- a/src/Iterator/GlobIterator.php
+++ b/src/Iterator/GlobIterator.php
@@ -53,7 +53,8 @@ class GlobIterator extends IteratorIterator
                 ('\\' !== DIRECTORY_SEPARATOR || false === strpos($glob, '[^'))
             ) {
                 // GLOB_BRACE is not available in some environments.
-                $results = glob($glob, defined('GLOB_BRACE') ? GLOB_BRACE : 0);
+                // $results = glob($glob, defined('GLOB_BRACE') ? GLOB_BRACE : 0);
+                $results = glob($glob, GLOB_BRACE);
 
                 // $results may be empty or false if $glob is invalid
                 if (empty($results)) {


### PR DESCRIPTION
Fixes #15