### PR TITLE
Fix composer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Installation
 Use [Composer] to install the package:
 
 ```
-$ composer require webmozart/glob
+composer require webmozart/glob
 ```
 
 Usage


### PR DESCRIPTION
The GitHub built-in "copy this" widget will copy the entire code block.  That includes the `$` character, which is not valid in the command.  This change makes the `composer require` block fully copy-paste-enter-able.