### PR TITLE
getBasePath() returns incorrect value for bare stream wrapper path

### DIFF
--- a/src/Glob.php
+++ b/src/Glob.php
@@ -270,6 +270,11 @@ final class Glob
                 return substr($staticPrefix, 0, $pos + 1);
             }
 
+            // If the prefix is a no-path custom stream, that's a valid base path.
+            if ($pos - 2 === strrpos($staticPrefix, '://')) {
+                return $staticPrefix;
+            }
+
             return substr($staticPrefix, 0, $pos);
         }
 

--- a/src/Path.php
+++ b/src/Path.php
@@ -46,7 +46,7 @@ abstract class Path
         }
 
         // UNIX root "/" or "\" (Windows style)
-        if ('/' === $path[0] || '\\' === $path[0]) {
+        if ($path === '' || '/' === $path[0] || '\\' === $path[0]) {
             return true;
         }
 

--- a/tests/GlobTest.php
+++ b/tests/GlobTest.php
@@ -790,6 +790,7 @@ class GlobTest extends \PHPUnit\Framework\TestCase
             array('/foo/baz\\*/bar', '/foo/baz*'),
             array('/foo/baz\\\\*/bar', '/foo'),
             array('/foo/baz\\\\\\*/bar', '/foo/baz\\*'),
+            array('', ''),
         );
     }
 

--- a/tests/GlobTest.php
+++ b/tests/GlobTest.php
@@ -769,7 +769,7 @@ class GlobTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider provideBasePaths
+     * @dataProvider provideBasePathsStream
      */
     public function testGetBasePathStream($glob, $basePath)
     {
@@ -790,8 +790,13 @@ class GlobTest extends \PHPUnit\Framework\TestCase
             array('/foo/baz\\*/bar', '/foo/baz*'),
             array('/foo/baz\\\\*/bar', '/foo'),
             array('/foo/baz\\\\\\*/bar', '/foo/baz\\*'),
-            array('', ''),
         );
+    }
+
+    public function provideBasePathsStream()
+    {
+        yield from $this->provideBasePaths();
+        yield ['', ''];
     }
 
     public function testGetBasePathFailsIfNotAbsolute()


### PR DESCRIPTION
I've run into a bug where trying to glob a stream path on just the root fails.  Specifically, in my app, `Glob::getBasePath('foo://');` returns `foo:/`, rather than `foo://`.  That means when trying to `Glob::glob('foo://*')`, the base path is wrong, so it cannot find any files.  Moreover, since PHP doesn't recognize `foo:/` as a file stream, whatever stream wrapper is registered for `foo` gets ignored.  (Specifically, the `elseif (is_dir($basePath))` clause comes back `false`, because there's no stream wrapper for `foo:/`, only for `foo://`.)

I believe the attached PR fixes the issue, though I defer to the maintainers if they'd prefer to take a slightly different approach.  I had to split the test cases up because presumably a path of `''` is not supposed to be supported as it's not absolute.

I... do not understand why the tests are failing with a permission denied error on PHP 8.0 only.  That feels spurious, but perhaps the maintainers have a better understanding of what gives.